### PR TITLE
[Feat] 일정 추가 모달 시작 날짜, 종료 날짜 수정 불가능하도록 수정

### DIFF
--- a/src/components/common/schedule-calendar/ScheduleCalendar.scss
+++ b/src/components/common/schedule-calendar/ScheduleCalendar.scss
@@ -1,7 +1,9 @@
 @import "src/presets";
 
 @mixin cell {
-  width: 15%;
+  width: -webkit-calc(100% / 7);
+  width: -moz-calc(100% / 7);
+  width: calc(100% / 7);
 
   color: #656565;
 

--- a/src/components/common/sliding-modal/SlidingModal.scss
+++ b/src/components/common/sliding-modal/SlidingModal.scss
@@ -44,6 +44,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      height: 6%;
 
       button {
         padding: 1.4vh 2.8vw;
@@ -72,6 +73,8 @@
 
     .body {
       padding-top: 2vh;
+      height: 94%;
+      overflow-y: auto;
     }
   }
 }

--- a/src/components/schedule-modal/components/add/ScheduleAddModal.tsx
+++ b/src/components/schedule-modal/components/add/ScheduleAddModal.tsx
@@ -5,6 +5,7 @@ import style from '@components/schedule-modal/ScheduleModal.scss';
 import SlidingModal from '@components/common/sliding-modal/SlidingModal';
 import ScheduleAddModalStore from '@components/schedule-modal/store/ScheduleAddModalStore';
 import TimeSelectPart from '@components/schedule-modal/components/common/TimeSelectPart';
+import { dayArray } from '@defines/defines';
 
 const cx = classNames.bind(style);
 
@@ -12,14 +13,31 @@ const store = ScheduleAddModalStore.instance;
 store.open({ year: 2022, month: 1, date: 2 });
 
 const ScheduleAddModal = observer(() => {
-    const { isOpened, close, startTime, endTime, setStartTime, setEndTime, startHourList, startMinuteList, endHourList, endMinuteList } = store;
+    const {
+        isOpened,
+        close,
+        selectedDate,
+        startTime,
+        endTime,
+        setStartTime,
+        setEndTime,
+        startHourList,
+        startMinuteList,
+        endHourList,
+        endMinuteList,
+    } = store;
+
+    const { year, month, date } = selectedDate;
+    const day = new Date(year, month - 1, date).getDay();
 
     return (
         <SlidingModal title={'일정 추가'} isOpened={isOpened} onClickConfirm={() => {}} onClickCancel={close}>
             <div className={cx('wrapper')}>
                 <div className={cx('part')}>
                     <h4>선택한 날짜</h4>
-                    <p>2021. 11. 12 (수)</p>
+                    <p>
+                        {year}. {month}. {date} ({dayArray[day]})
+                    </p>
                 </div>
 
                 <div className={cx('part')}>

--- a/src/components/schedule-modal/components/add/ScheduleAddModal.tsx
+++ b/src/components/schedule-modal/components/add/ScheduleAddModal.tsx
@@ -4,37 +4,15 @@ import classNames from 'classnames/bind';
 import style from '@components/schedule-modal/ScheduleModal.scss';
 import SlidingModal from '@components/common/sliding-modal/SlidingModal';
 import ScheduleAddModalStore from '@components/schedule-modal/store/ScheduleAddModalStore';
-import DateSelectPart from '@components/schedule-modal/components/common/DateSelectPart';
 import TimeSelectPart from '@components/schedule-modal/components/common/TimeSelectPart';
 
 const cx = classNames.bind(style);
 
 const store = ScheduleAddModalStore.instance;
+store.open({ year: 2022, month: 1, date: 2 });
 
 const ScheduleAddModal = observer(() => {
-    const {
-        isOpened,
-        close,
-        startDatetime,
-        endDatetime,
-        yearList,
-        startMonthList,
-        endMonthList,
-        startDateList,
-        endDateList,
-        setStartYear,
-        setStartMonth,
-        setStartDate,
-        setStartHours,
-        setStartMinutes,
-        setEndYear,
-        setEndMonth,
-        setEndDate,
-        setEndHours,
-        setEndMinutes,
-        hoursList,
-        minutesList,
-    } = store;
+    const { isOpened, close, startTime, endTime, setStartTime, setEndTime, startHourList, startMinuteList, endHourList, endMinuteList } = store;
 
     return (
         <SlidingModal title={'일정 추가'} isOpened={isOpened} onClickConfirm={() => {}} onClickCancel={close}>
@@ -49,51 +27,22 @@ const ScheduleAddModal = observer(() => {
                     <input placeholder={'일정의 이름을 입력하세요.'} />
                 </div>
 
-                <DateSelectPart
-                    title={'시작 일'}
-                    year={startDatetime.year}
-                    month={startDatetime.month}
-                    date={startDatetime.date}
-                    yearList={yearList}
-                    monthList={startMonthList}
-                    dateList={startDateList}
-                    onChangeYear={setStartYear}
-                    onChangeMonth={setStartMonth}
-                    onChangeDate={setStartDate}
-                    disabled
-                />
-
                 <TimeSelectPart
                     title={'시작 시간'}
-                    hours={startDatetime.hours}
-                    minutes={startDatetime.minutes}
-                    hoursList={hoursList}
-                    minutesList={minutesList}
-                    onChangeHours={setStartHours}
-                    onChangeMinutes={setStartMinutes}
-                />
-
-                <DateSelectPart
-                    title={'종료 일'}
-                    year={endDatetime.year}
-                    month={endDatetime.month}
-                    date={endDatetime.date}
-                    yearList={yearList}
-                    monthList={endMonthList}
-                    dateList={endDateList}
-                    onChangeYear={setEndYear}
-                    onChangeMonth={setEndMonth}
-                    onChangeDate={setEndDate}
+                    hour={startTime.hour}
+                    minute={startTime.minute}
+                    hourList={startHourList}
+                    minuteList={startMinuteList}
+                    onChangeTime={setStartTime}
                 />
 
                 <TimeSelectPart
                     title={'종료 시간'}
-                    hours={endDatetime.hours}
-                    minutes={endDatetime.minutes}
-                    hoursList={hoursList}
-                    minutesList={minutesList}
-                    onChangeHours={setEndHours}
-                    onChangeMinutes={setEndMinutes}
+                    hour={endTime.hour}
+                    minute={endTime.minute}
+                    hourList={endHourList}
+                    minuteList={endMinuteList}
+                    onChangeTime={setEndTime}
                 />
 
                 <div className={cx('part')}>

--- a/src/components/schedule-modal/components/common/TimeSelectPart.tsx
+++ b/src/components/schedule-modal/components/common/TimeSelectPart.tsx
@@ -2,53 +2,46 @@ import React, { ChangeEvent } from 'react';
 import { observer } from 'mobx-react';
 import classNames from 'classnames/bind';
 import style from '@components/schedule-modal/ScheduleModal.scss';
+import { Time } from '@defines/defines';
 
 const cx = classNames.bind(style);
 
 export interface TimeSelectPartProps {
     title: string;
-    hours: number;
-    minutes: number;
-    hoursList: number[];
-    minutesList: number[];
-    onChangeHours: (hours: number) => void;
-    onChangeMinutes: (minutes: number) => void;
+    hour: number;
+    minute: number;
+    hourList: number[];
+    minuteList: number[];
+    onChangeTime: (time: Time) => void;
 }
 
 const TimeSelectPart = observer((props: TimeSelectPartProps) => {
-    const { title, hours, minutes, hoursList, minutesList, onChangeHours, onChangeMinutes } = props;
+    const { title, hour, minute, hourList, minuteList, onChangeTime } = props;
 
     const onChange = (e: ChangeEvent<HTMLSelectElement>, callback: (value: number) => void) => {
         callback(Number(e.target.value));
     };
 
+    const onChangeHour = (hour) => onChangeTime({ hour, minute });
+    const onChangeMinute = (minute) => onChangeTime({ hour, minute });
+
     return (
         <div className={cx('part')}>
             <h4>{title}</h4>
             <div className={cx('datetime')}>
-                <select defaultValue={hours} onChange={(e) => onChange(e, onChangeHours)}>
-                    {[
-                        <option key={`${title}_hours`} value={-1}>
-                            시
-                        </option>,
-                        ...hoursList.map((hours) => (
-                            <option key={hours} value={hours}>
-                                {hours}
-                            </option>
-                        )),
-                    ]}
+                <select value={hour} onChange={(e) => onChange(e, onChangeHour)}>
+                    {hourList.map((hour) => (
+                        <option key={hour} value={hour}>
+                            {hour}
+                        </option>
+                    ))}
                 </select>
-                <select defaultValue={minutes} onChange={(e) => onChange(e, onChangeMinutes)}>
-                    {[
-                        <option key={`${title}_minutes`} value={-1}>
-                            분
-                        </option>,
-                        ...minutesList.map((minutes) => (
-                            <option key={minutes} value={minutes}>
-                                {minutes}
-                            </option>
-                        )),
-                    ]}
+                <select value={minute} onChange={(e) => onChange(e, onChangeMinute)}>
+                    {minuteList.map((minute) => (
+                        <option key={minute} value={minute}>
+                            {minute}
+                        </option>
+                    ))}
                 </select>
             </div>
         </div>

--- a/src/components/schedule-modal/store/ScheduleAddModalStore.ts
+++ b/src/components/schedule-modal/store/ScheduleAddModalStore.ts
@@ -1,18 +1,14 @@
 import { autobind } from 'core-decorators';
-import { action, observable } from 'mobx';
-import Datetime from '@utils/Datetime';
+import { action } from 'mobx';
 import ScheduleModalStore from '@components/schedule-modal/store/ScheduleModalStore';
 
 @autobind
 export default class ScheduleAddModalStore extends ScheduleModalStore {
     private static _instance: ScheduleAddModalStore;
 
-    @observable private _selectedDatetime: Datetime;
-
     private constructor() {
         super();
         ScheduleAddModalStore._instance = this;
-        this.init();
     }
 
     static get instance() {
@@ -22,16 +18,23 @@ export default class ScheduleAddModalStore extends ScheduleModalStore {
         return this._instance;
     }
 
+    /**
+     * 모달이 새로 열릴때마다 초기화 실행
+     * @param calendarDate
+     * @protected
+     */
     @action
-    setSelectedDatetime(selectedDatetime: Datetime) {
-        this._selectedDatetime = selectedDatetime;
-    }
+    protected init(calendarDate) {
+        super.init(calendarDate);
 
-    @action
-    protected init() {
-        const today = new Date();
+        this.setEndTime({
+            hour: 23,
+            minute: 50,
+        });
 
-        this.setStartDatetime(this.getInitStartDatetime(today));
-        this.setEndDatetime(this.getInitEndDatetime(today));
+        this.setStartTime({
+            hour: 0,
+            minute: 0,
+        });
     }
 }

--- a/src/components/schedule-modal/store/ScheduleModalStore.ts
+++ b/src/components/schedule-modal/store/ScheduleModalStore.ts
@@ -21,6 +21,10 @@ export default class ScheduleModalStore extends ModalStore {
     // 위치
     @observable private _location: string = '';
 
+    get selectedDate(): CalendarDate {
+        return this._selectedDate;
+    }
+
     get name(): string {
         return this._name;
     }

--- a/src/components/schedule-modal/store/ScheduleModalStore.ts
+++ b/src/components/schedule-modal/store/ScheduleModalStore.ts
@@ -1,84 +1,56 @@
 import { autobind } from 'core-decorators';
 import { action, observable } from 'mobx';
-import Datetime from '@utils/Datetime';
 import ModalStore from '@stores/ModalStore';
 import { dialog } from '@components/common/dialog/Dialog';
-import { EYear } from '@defines/defines';
+import { CalendarDate, Time } from '@defines/defines';
 
 @autobind
 export default class ScheduleModalStore extends ModalStore {
+    // 일정을 추가, 수정하려는 날짜
+    @observable private _selectedDate: CalendarDate;
+
     // 일정 이름
     @observable private _name: string = '';
 
-    // 시작 일시
-    @observable private _startDatetime: Datetime;
+    // 시작 시간
+    @observable private _startTime: Time;
 
-    // 종료 일시
-    @observable private _endDatetime: Datetime;
+    // 종료 시간
+    @observable private _endTime: Time;
 
     // 위치
     @observable private _location: string = '';
-
-    // 시작 월에 따른 일
-    @observable private _startDateList: number[] = [];
-
-    // 종료 월에 따른 일
-    @observable private _endDateList: number[] = [];
-
-    // 시작 연도 선택에 따른 월
-    @observable private _startMonthList: number[] = [];
-
-    // 종료 연도 선택에 따른 월
-    @observable private _endMonthList: number[] = [];
-
-    private _yearList: number[] = this.getYearList();
-
-    private _hoursList: number[] = this.getHoursList();
-
-    private _minutesList: number[] = this.getMinutesList();
 
     get name(): string {
         return this._name;
     }
 
-    get startDatetime(): Datetime {
-        return this._startDatetime;
+    get startTime(): Time {
+        return this._startTime;
     }
 
-    get endDatetime(): Datetime {
-        return this._endDatetime;
+    get endTime(): Time {
+        return this._endTime;
     }
 
     get location(): string {
         return this._location;
     }
 
-    get startDateList(): number[] {
-        return this._startDateList;
+    get startHourList(): number[] {
+        return this.getStartHourList();
     }
 
-    get endDateList(): number[] {
-        return this._endDateList;
+    get endHourList(): number[] {
+        return this.getEndHourList();
     }
 
-    get startMonthList(): number[] {
-        return this._startMonthList;
+    get startMinuteList(): number[] {
+        return this.getStartMinuteList();
     }
 
-    get endMonthList(): number[] {
-        return this._endMonthList;
-    }
-
-    get yearList(): number[] {
-        return this._yearList;
-    }
-
-    get hoursList(): number[] {
-        return this._hoursList;
-    }
-
-    get minutesList(): number[] {
-        return this._minutesList;
+    get endMinuteList(): number[] {
+        return this.getEndMinuteList();
     }
 
     @action
@@ -87,109 +59,22 @@ export default class ScheduleModalStore extends ModalStore {
     }
 
     @action
-    setStartDatetime(datetime: Datetime) {
-        const { year, month } = datetime;
-        this._startDatetime = datetime;
-        this._startMonthList = this.getMonthList();
-        this._startDateList = this.getDateList(year, month);
-    }
-
-    @action
-    setEndDatetime(datetime: Datetime) {
-        const { year, month } = datetime;
-        this._endDatetime = datetime;
-        this._endMonthList = this.getMonthList();
-        this._endDateList = this.getDateList(year, month);
-    }
-
-    @action
-    setStartYear(year: number) {
-        if (this.isOutOfRange(year, EYear.MIN_YEAR, EYear.MAX_YEAR)) {
+    setStartTime(time: Time) {
+        const { hour, minute } = time;
+        if (ScheduleModalStore.isOutOfRange(hour, 0, 23) || ScheduleModalStore.isOutOfRange(minute, 0, 59)) {
             return;
         }
-        this._startDatetime.year = year;
-
-        if (this._startMonthList.length < 2) {
-            this._startMonthList = this.getMonthList();
-        }
+        this._startTime = time;
+        this.setEndTimeIfInvalid();
     }
 
     @action
-    setStartMonth(month: number) {
-        if (this.isOutOfRange(month, 1, 12)) {
+    setEndTime(time: Time) {
+        const { hour, minute } = time;
+        if (ScheduleModalStore.isOutOfRange(hour, 0, 23) || ScheduleModalStore.isOutOfRange(minute, 0, 59)) {
             return;
         }
-        this._startDatetime.month = month;
-        this._startDateList = this.getDateList(this._startDatetime.year, month);
-    }
-
-    @action
-    setStartDate(date: number) {
-        if (this.isOutOfRange(date, 1, this._startDateList[this._startDateList.length - 1])) {
-            return;
-        }
-        this._startDatetime.date = date;
-    }
-
-    @action
-    setStartHours(hours: number) {
-        if (this.isOutOfRange(hours, 0, 23)) {
-            return;
-        }
-        this._startDatetime.hours = hours;
-    }
-
-    @action
-    setStartMinutes(minutes: number) {
-        if (this.isOutOfRange(minutes, 0, 59)) {
-            return;
-        }
-        this._startDatetime.minutes = minutes;
-    }
-
-    @action
-    setEndYear(year: number) {
-        if (this.isOutOfRange(year, EYear.MIN_YEAR, EYear.MAX_YEAR)) {
-            return;
-        }
-        this._endDatetime.year = year;
-
-        if (this._endMonthList.length < 2) {
-            this._endMonthList = this.getMonthList();
-        }
-    }
-
-    @action
-    setEndMonth(month: number) {
-        if (this.isOutOfRange(month, 1, 12)) {
-            return;
-        }
-        this._endDatetime.month = month;
-        this._endDateList = this.getDateList(this._endDatetime.year, month);
-    }
-
-    @action
-    setEndDate(date: number) {
-        if (this.isOutOfRange(date, 1, this._endDateList[this._endDateList.length - 1])) {
-            return;
-        }
-        this._endDatetime.date = date;
-    }
-
-    @action
-    setEndHours(hours: number) {
-        if (this.isOutOfRange(hours, 0, 23)) {
-            return;
-        }
-        this._endDatetime.hours = hours;
-    }
-
-    @action
-    setEndMinutes(minutes: number) {
-        if (this.isOutOfRange(minutes, 0, 59)) {
-            return;
-        }
-        this._endDatetime.minutes = minutes;
+        this._endTime = time;
     }
 
     @action
@@ -198,61 +83,68 @@ export default class ScheduleModalStore extends ModalStore {
     }
 
     @action
-    protected getInitStartDatetime(today: Date) {
-        return new Datetime(today.getFullYear(), today.getMonth() + 1, today.getDate(), 0, 0);
+    protected init(selectedDate: CalendarDate) {
+        this._selectedDate = selectedDate;
     }
 
-    @action
-    protected getInitEndDatetime(today: Date) {
-        return new Datetime(today.getFullYear(), today.getMonth() + 1, today.getDate(), 23, 50);
+    private getStartHourList() {
+        return ScheduleModalStore.getValueList(0, 23, 1);
     }
 
-    protected getYearList() {
+    private getEndHourList() {
+        return ScheduleModalStore.getValueList(this.startTime.hour, 23, 1);
+    }
+
+    private getStartMinuteList() {
+        return ScheduleModalStore.getValueList(0, 50, 10);
+    }
+
+    private getEndMinuteList() {
+        const minMinute = this.startTime.hour === this.endTime.hour ? this.startTime.minute : 0;
+        return ScheduleModalStore.getValueList(minMinute, 50, 10);
+    }
+
+    private static getValueList(min: number, max: number, interval: number): number[] {
         const arr = [];
-        for (let i = EYear.MIN_YEAR; i <= EYear.MAX_YEAR; i++) {
+        for (let i = min; i <= max; i += interval) {
             arr.push(i);
         }
         return arr;
     }
 
-    protected getMonthList() {
-        const arr = [];
-        for (let i = 1; i < 13; i++) {
-            arr.push(i);
-        }
-        return arr;
-    }
-
-    protected getDateList(year: number, month: number) {
-        const lastDate = new Date(year, month, 0).getDate();
-        const arr = [];
-        for (let i = 1; i <= lastDate; i++) {
-            arr.push(i);
-        }
-        return arr;
-    }
-
-    protected getHoursList() {
-        const arr = [];
-        for (let i = 0; i < 24; i++) {
-            arr.push(i);
-        }
-        return arr;
-    }
-
-    protected getMinutesList() {
-        const arr = [];
-        for (let i = 0; i < 60; i += 10) {
-            arr.push(i);
-        }
-        return arr;
-    }
-
-    protected isOutOfRange(value: number, min: number, max: number) {
+    private static isOutOfRange(value: number, min: number, max: number) {
         if (value < min || value > max) {
             dialog.alert('허용된 범위 밖입니다.');
             return true;
         }
         return false;
+    }
+
+    /**
+     * 시작 시간 변경 시 종료 시간이 시작 시간보다 앞서 있으면 종료 시간 변경
+     * @private
+     */
+    private setEndTimeIfInvalid() {
+        const { hour, minute } = this.startTime;
+
+        let endHour = this.endTime.hour;
+        let endMinute = this.endTime.minute;
+
+        if (this.isEndTimeEarlierThanStartTime()) {
+            if (hour > endHour) {
+                endHour = hour;
+            }
+            if (hour === endHour && minute > endMinute) {
+                endMinute = minute;
+            }
+        }
+        this.setEndTime({ hour: endHour, minute: endMinute });
+    }
+
+    /**
+     * 종료 시간이 시작 시간보다 앞섰는지 검사
+     */
+    private isEndTimeEarlierThanStartTime() {
+        return this.startTime.hour > this.endTime.hour || (this.startTime.hour === this.endTime.hour && this._startTime.minute > this.endTime.minute);
     }
 }

--- a/src/defines/defines.ts
+++ b/src/defines/defines.ts
@@ -38,6 +38,11 @@ export interface CalendarDate {
     year: number;
 }
 
+export interface Time {
+    hour: number;
+    minute: number;
+}
+
 export interface Schedule {
     startDatetime: Datetime;
     endDatetime: Datetime;

--- a/src/stores/ModalStore.ts
+++ b/src/stores/ModalStore.ts
@@ -10,9 +10,10 @@ export default class ModalStore {
     }
 
     @action
-    open() {
+    open(initObj?: any, openCallback?: () => void) {
         this._isOpened = true;
-        this.init();
+        this.init(initObj);
+        openCallback && openCallback();
     }
 
     @action
@@ -20,5 +21,5 @@ export default class ModalStore {
         this._isOpened = false;
     }
 
-    protected init() {}
+    protected init(initObj?: any) {}
 }


### PR DESCRIPTION
issue #8 
## 📋 작업 내용
- [x] 달력 셀 너비 css 변경
- [x] 일정 추가 모달 스크롤되도록 css 수정
- [x] 일정 추가 모달에서 시작 날짜, 종료 날짜 선택 UI 삭제
- [x] 시작 시간 선택 후 종료 시간 선택 시 종료 시간은 시작 시간 이전으로 선택할 수 없도록 구현
- [x] 시작 시간 선택 시 종료 시간이 시작 시간 이전이라면 시작 시간 이후로 자동 변경

## 📌 PR Point
- 데이터베이스 구조를 고려하여 하나의 일정은 하나의 날짜에만 포함되도록 수정이 필요
- 코드 리뷰하면서 수정이 필요한 부분 이외에도 질문하고 싶은 내용은 코멘트 남겨주세용~

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/44297538/147855983-9a45b470-3984-4f29-aa57-457a35a08ab3.png)
