### PR TITLE
[Feat] 날짜별 일정 조회

### DIFF
--- a/src/components/date-detail-menu/DateDetailMenu.tsx
+++ b/src/components/date-detail-menu/DateDetailMenu.tsx
@@ -13,7 +13,7 @@ const cx = classNames.bind(style);
 const calendarStore = ScheduleCalendarStore.instance;
 
 const DateDetailMenu = observer(() => {
-    const { selectCalendarDate, selectedCalendarDate } = calendarStore;
+    const { selectCalendarDate, selectedCalendarDate, selectedDateScheduleList } = calendarStore;
 
     const close = () => selectCalendarDate(null);
 
@@ -27,38 +27,9 @@ const DateDetailMenu = observer(() => {
 
                     <div className={cx('body')}>
                         <div className={cx('card-wrapper')}>
-                            <Card
-                                schedule={{
-                                    scheduleDate: { year: 2021, month: 11, date: 24 },
-                                    startTime: { hour: 10, minute: 0 },
-                                    endTime: { hour: 13, minute: 20 },
-                                    name: '뭐하기',
-                                }}
-                            />
-                            <Card
-                                schedule={{
-                                    scheduleDate: { year: 2021, month: 11, date: 24 },
-                                    startTime: { hour: 10, minute: 0 },
-                                    endTime: { hour: 13, minute: 20 },
-                                    name: '뭐하기',
-                                }}
-                            />
-                            <Card
-                                schedule={{
-                                    scheduleDate: { year: 2021, month: 11, date: 24 },
-                                    startTime: { hour: 10, minute: 0 },
-                                    endTime: { hour: 13, minute: 20 },
-                                    name: '뭐하기',
-                                }}
-                            />
-                            <Card
-                                schedule={{
-                                    scheduleDate: { year: 2021, month: 11, date: 24 },
-                                    startTime: { hour: 10, minute: 0 },
-                                    endTime: { hour: 13, minute: 20 },
-                                    name: '뭐하기',
-                                }}
-                            />
+                            {selectedDateScheduleList.map((schedule) => (
+                                <Card key={`${schedule.owner}_${schedule.name}`} schedule={schedule} />
+                            ))}
                         </div>
 
                         <ScheduleAddButton />

--- a/src/components/schedule-calendar/ScheduleCalendar.scss
+++ b/src/components/schedule-calendar/ScheduleCalendar.scss
@@ -108,14 +108,14 @@
         ul {
           @include hideScrollbar;
           max-width: 100%;
-          height: 55%;
+          height: 50%;
           overflow-y: auto;
           border-radius: 2px;
           padding: 0 0.4vw;
           transition: height ease-in-out .2s;
 
           &.reduced {
-            height: 8%;
+            height: 5%;
           }
 
           li {

--- a/src/components/schedule-modal/store/ScheduleAddModalStore.ts
+++ b/src/components/schedule-modal/store/ScheduleAddModalStore.ts
@@ -2,13 +2,14 @@ import { autobind } from 'core-decorators';
 import { action } from 'mobx';
 import ScheduleModalStore from '@components/schedule-modal/store/ScheduleModalStore';
 import UserStore from '@stores/UserStore';
-import { FormatUtil } from '@utils/FormatUtil';
 import { dialog } from '@components/common/dialog/Dialog';
 import { ScheduleModalRequest } from '@requests/ScheduleModalRequest';
+import ScheduleCalendarStore from '@components/schedule-calendar/store/ScheduleCalendarStore';
 
 @autobind
 export default class ScheduleAddModalStore extends ScheduleModalStore {
     private static _instance: ScheduleAddModalStore;
+    private _scheduleCalendarStore = ScheduleCalendarStore.instance;
 
     private constructor() {
         super();
@@ -65,6 +66,12 @@ export default class ScheduleAddModalStore extends ScheduleModalStore {
             unableToMeet,
         });
 
-        dialog.alert('저장했습니다.', this.close);
+        dialog.alert('저장했습니다.', () => {
+            (async () => {
+                await this._scheduleCalendarStore.setDateList();
+                this._scheduleCalendarStore.selectCalendarDate(null);
+                this.close();
+            })();
+        });
     }
 }

--- a/src/requests/ScheduleCalendarRequest.ts
+++ b/src/requests/ScheduleCalendarRequest.ts
@@ -3,9 +3,17 @@ import { Collections } from '@collections/Collections';
 import { FormatUtil } from '@utils/FormatUtil';
 import { ScheduleVO } from '@models/ScheduleVO';
 import { loading } from '@components/common/loading/Loading';
+import firebase from 'firebase/app';
+import { DocumentData } from '@defines/firebaseDefines';
 
 export namespace ScheduleCalendarRequest {
-    export async function getThisMonthSchedules(year: number, month: number, lastDate: number): Promise<Schedule[]> {
+    /**
+     * 이번 달 일정 목록 조회
+     * @param year
+     * @param month
+     * @param lastDate
+     */
+    export async function getSchedulesOfMonth(year: number, month: number, lastDate: number): Promise<Schedule[]> {
         loading.show();
         const { docs } = await Collections.schedule.getOrderBy('scheduleDate', [
             {
@@ -21,6 +29,24 @@ export namespace ScheduleCalendarRequest {
         ]);
         loading.hide();
 
+        return getScheduleListFromScheduleVODocs(docs);
+    }
+
+    export async function getSchedulesOfDate(year: number, month: number, date: number): Promise<Schedule[]> {
+        loading.show();
+        const { docs } = await Collections.schedule.get([
+            {
+                fieldPath: 'scheduleDate',
+                opStr: '==',
+                value: FormatUtil.calendarDateToString({ year, month, date }),
+            },
+        ]);
+        loading.hide();
+
+        return getScheduleListFromScheduleVODocs(docs);
+    }
+
+    function getScheduleListFromScheduleVODocs(docs: firebase.firestore.QueryDocumentSnapshot<DocumentData>[]): Schedule[] {
         return docs.map((doc) => {
             const vo = doc.data() as ScheduleVO;
             const { owner, scheduleDate, name, startTime, endTime, location, isDate, unableToMeet } = vo;


### PR DESCRIPTION
#23 
## 📋 작업 내용
- [x] 날짜 클릭 시 선택한 날짜의 일정 목록 조회
- [x] 조회한 일정 목록 렌더링
- [x] 일정 추가 후 모달 닫히기 전 선택된 달의 일정 목록 조회

## 📌 PR Point
- 날짜별 일정 보기가 구현되었습니다!
- 월별, 날짜별 일정 목록 조회가 구현되었고 주별 일정 목록 조회도 ScheduleCalendarRequest.ts 파일에 구현 예정

## 📷 스크린샷
<img src="https://user-images.githubusercontent.com/44297538/149628415-d7d1187b-15e6-4ebf-a1bc-5c8a596c3fda.png" width="30%" />
