### PR TITLE
[Feat] 주간 일정 조회

### DIFF
--- a/src/components/navigation/Navigation.scss
+++ b/src/components/navigation/Navigation.scss
@@ -9,8 +9,6 @@
 }
 
 .wrapper {
-    position: fixed;
-    width: 100%;
     height: 10vh;
     display: flex;
     align-items: center;

--- a/src/requests/ScheduleCalendarRequest.ts
+++ b/src/requests/ScheduleCalendarRequest.ts
@@ -5,10 +5,11 @@ import { ScheduleVO } from '@models/ScheduleVO';
 import { loading } from '@components/common/loading/Loading';
 import firebase from 'firebase/app';
 import { DocumentData } from '@defines/firebaseDefines';
+import { DateUtil } from '@utils/DateUtil';
 
 export namespace ScheduleCalendarRequest {
     /**
-     * 이번 달 일정 목록 조회
+     * 특정 달 일정 목록 조회
      * @param year
      * @param month
      * @param lastDate
@@ -32,6 +33,41 @@ export namespace ScheduleCalendarRequest {
         return getScheduleListFromScheduleVODocs(docs);
     }
 
+    /**
+     * 특정 주 일정 목록 조회
+     * @param year
+     * @param month
+     * @param date
+     */
+    export async function getSchedulesOfWeek(year: number, month: number, date: number): Promise<Schedule[]> {
+        loading.show();
+        const dateList = DateUtil.getThisWeek({ year, month, date });
+        const firstDate = dateList[0];
+        const lastDate = dateList[6];
+
+        const { docs } = await Collections.schedule.getOrderBy({ fieldPath: 'scheduleDate' }, [
+            {
+                fieldPath: 'scheduleDate',
+                opStr: '>=',
+                value: FormatUtil.calendarDateToString({ year: firstDate.year, month: firstDate.month, date: firstDate.date }),
+            },
+            {
+                fieldPath: 'scheduleDate',
+                opStr: '<=',
+                value: FormatUtil.calendarDateToString({ year: lastDate.year, month: lastDate.month, date: lastDate.date }),
+            },
+        ]);
+        loading.hide();
+
+        return getScheduleListFromScheduleVODocs(docs);
+    }
+
+    /**
+     * 특정 날 일정 목록 조회
+     * @param year
+     * @param month
+     * @param date
+     */
     export async function getSchedulesOfDate(year: number, month: number, date: number): Promise<Schedule[]> {
         loading.show();
         const { docs } = await Collections.schedule.get([


### PR DESCRIPTION
## 📋 작업 내용
- [x] 주간 일정 조회

## 📌 PR Point
- 주간 일정 조회 시 특정 주의 아무 날짜(년, 월, 일)을 인자로 전달
- 일정 목록은 날짜의 오름차순으로 조회됨
- 주간 일정 조회 시 ScheduleCalendarStore의 아래 코드 참고하세요
  ```typescript
  // 이번 달 일정 조회
  const scheduleList = await ScheduleCalendarRequest.getSchedulesOfMonth(this.curYear, this.curMonth, lastDate);
  ```
