### PR TITLE
[Feat] 통계 페이지 > 주간 통계 기능 추가

### DIFF
--- a/src/components/common/chart-bar/ChartBar.scss
+++ b/src/components/common/chart-bar/ChartBar.scss
@@ -1,0 +1,23 @@
+.wrapper {
+    position: relative;
+
+    .inside {
+        @keyframes fillChartAnimation {
+            from {
+                height: 0%;
+            }
+            to {
+                height: 100%;
+            }
+        }
+
+        position: absolute;
+        bottom: 0;
+        animation-name: fillChartAnimation;
+        animation-duration: 2s;
+        animation-fill-mode: forwards;
+        width: 100%;
+        border-top-left-radius: 2vw;
+        border-top-right-radius: 2vw;
+    }
+}

--- a/src/components/common/chart-bar/ChartBar.tsx
+++ b/src/components/common/chart-bar/ChartBar.tsx
@@ -5,16 +5,17 @@ import style from './ChartBar.scss';
 const cx = classNames.bind(style);
 
 export interface ChartBarProps {
-    width: number;
+    width: number | string;
     percentage: number;
     color: string;
 }
 
 const ChartBar = (props: ChartBarProps) => {
     const { width, percentage, color } = props;
+    const widthValue = typeof(width) === 'number' ? `${width}px` : width;
 
     const chartBarOutsideStyle = {
-        width: `${width}vw`,
+        width: widthValue,
         height: `${percentage}%`,
     };
 

--- a/src/components/common/chart-bar/ChartBar.tsx
+++ b/src/components/common/chart-bar/ChartBar.tsx
@@ -19,7 +19,7 @@ const ChartBar = (props: ChartBarProps) => {
     };
 
     const chartBarInsideStyle = {
-        background: `${color}`,
+        background: color,
     };
 
     return (

--- a/src/components/common/chart-bar/ChartBar.tsx
+++ b/src/components/common/chart-bar/ChartBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import style from './ChartBar.scss';
+
+const cx = classNames.bind(style);
+
+export interface ChartBarProps {
+    width: number;
+    percentage: number;
+    color: string;
+}
+
+const ChartBar = (props: ChartBarProps) => {
+    const { width, percentage, color } = props;
+
+    const chartBarOutsideStyle = {
+        width: `${width}vw`,
+        height: `${percentage}%`,
+    };
+
+    const chartBarInsideStyle = {
+        background: `${color}`,
+    };
+
+    return (
+        <div className={cx('wrapper')} style={chartBarOutsideStyle}>
+            <div className={cx('inside')} style={chartBarInsideStyle}></div>
+        </div>
+    );
+};
+
+export default ChartBar;

--- a/src/components/common/chart-bar/ChartBar.tsx
+++ b/src/components/common/chart-bar/ChartBar.tsx
@@ -12,10 +12,9 @@ export interface ChartBarProps {
 
 const ChartBar = (props: ChartBarProps) => {
     const { width, percentage, color } = props;
-    const widthValue = typeof(width) === 'number' ? `${width}px` : width;
 
     const chartBarOutsideStyle = {
-        width: widthValue,
+        width: typeof(width) === 'number' ? `${width}px` : width,
         height: `${percentage}%`,
     };
 

--- a/src/components/common/date-slider/DateSlide.tsx
+++ b/src/components/common/date-slider/DateSlide.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames/bind';
 import style from './DateSlide.scss';
 import { observer } from 'mobx-react-lite';
 import WeeklyScheduleStore from '@stores/WeeklyScheduleStore';
-import { DateUtil } from '@utils/DateUtil';
 
 const cx = classNames.bind(style);
 

--- a/src/components/common/period-selector/PeriodSelector.scss
+++ b/src/components/common/period-selector/PeriodSelector.scss
@@ -1,0 +1,23 @@
+.wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 0 auto;
+    margin-bottom: 4vh;
+    width: 60vw;
+
+    button {
+        &:disabled svg path {
+            fill: lightgray;
+        }
+
+        div {
+            display: flex;
+            align-items: center;
+        }
+    }
+
+    svg path {
+        fill: #9e5ade;
+    }
+}

--- a/src/components/common/period-selector/PeriodSelector.tsx
+++ b/src/components/common/period-selector/PeriodSelector.tsx
@@ -10,20 +10,21 @@ const cx = classNames.bind(style);
 export interface PeriodSelectorProps {
     toPrev: () => void;
     toNext: () => void;
-    disabled?: boolean;
+    isPrevDisabled?: boolean;
+    isNextDisabled?: boolean;
     children?: ReactNode;
 }
 
 const PeriodSelector = observer((props: PeriodSelectorProps) => {
-    const { toPrev, toNext, disabled = false, children } = props;
+    const { toPrev, toNext, isPrevDisabled = false, isNextDisabled = false, children } = props;
 
     return (
         <div className={cx('wrapper')}>
-            <button onClick={toPrev}>
+            <button onClick={toPrev} disabled={isPrevDisabled}>
                 <ArrowIcon direction={EArrowDirection.LEFT} />
             </button>
             {children && <span>{children}</span>}
-            <button onClick={toNext} disabled={disabled}>
+            <button onClick={toNext} disabled={isNextDisabled}>
                 <ArrowIcon direction={EArrowDirection.RIGHT} />
             </button>
         </div>

--- a/src/components/common/period-selector/PeriodSelector.tsx
+++ b/src/components/common/period-selector/PeriodSelector.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+import { observer } from 'mobx-react';
+import classNames from 'classnames/bind';
+import style from './PeriodSelector.scss';
+import ArrowIcon from '@icons/arrow/ArrowIcon';
+import { EArrowDirection } from '@defines/defines';
+
+const cx = classNames.bind(style);
+
+export interface PeriodSelectorProps {
+    toPrev: () => void;
+    toNext: () => void;
+    disabled?: boolean;
+    children?: ReactNode;
+}
+
+const PeriodSelector = observer((props: PeriodSelectorProps) => {
+    const { toPrev, toNext, disabled = false, children } = props;
+
+    return (
+        <div className={cx('wrapper')}>
+            <button onClick={toPrev}>
+                <ArrowIcon direction={EArrowDirection.LEFT} />
+            </button>
+            {children && <span>{children}</span>}
+            <button onClick={toNext} disabled={disabled}>
+                <ArrowIcon direction={EArrowDirection.RIGHT} />
+            </button>
+        </div>
+    );
+});
+
+export default PeriodSelector;

--- a/src/components/weekly-statistics/WeeklyStatistics.scss
+++ b/src/components/weekly-statistics/WeeklyStatistics.scss
@@ -23,31 +23,6 @@
             display: flex;
             align-items: flex-end;
             gap: 0.5vw;
-
-            & > div {
-                position: relative;
-                width: 4vw;
-
-                & > div {
-                    @keyframes fillChartAnimation {
-                        from {
-                            height: 0%;
-                        }
-                        to {
-                            height: 100%;
-                        }
-                    }
-
-                    position: absolute;
-                    bottom: 0;
-                    animation-name: fillChartAnimation;
-                    animation-duration: 2s;
-                    animation-fill-mode: forwards;
-                    width: 100%;
-                    border-top-left-radius: 2vw;
-                    border-top-right-radius: 2vw;
-                }
-            }
         }
     }
 

--- a/src/components/weekly-statistics/WeeklyStatistics.scss
+++ b/src/components/weekly-statistics/WeeklyStatistics.scss
@@ -1,28 +1,4 @@
 .wrapper {
-    .arrow-container {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin: 0 auto;
-        margin-bottom: 4vh;
-        width: 60vw;
-
-        button {
-            &:disabled svg path {
-                fill: lightgray;
-            }
-
-            div {
-                display: flex;
-                align-items: center;
-            }
-        }
-
-        svg path {
-            fill: #9e5ade;
-        }
-    }
-
     .chart {
         display: flex;
 

--- a/src/components/weekly-statistics/WeeklyStatistics.tsx
+++ b/src/components/weekly-statistics/WeeklyStatistics.tsx
@@ -39,8 +39,8 @@ const WeeklyStatistics = observer(() => {
                         const { me, other } = scheduleCountInfo;
                         return (
                             <div key={FormatUtil.calendarDateToString(calendarDate)} className={cx('bar')}>
-                                <ChartBar width={4} percentage={NumberUtil.getPercentage(me, maxScheduleCount)} color="#a34dff"></ChartBar>
-                                <ChartBar width={4} percentage={NumberUtil.getPercentage(other, maxScheduleCount)} color="#c482ff"></ChartBar>
+                                <ChartBar width={'4vw'} percentage={NumberUtil.getPercentage(me, maxScheduleCount)} color="#a34dff"></ChartBar>
+                                <ChartBar width={'4vw'} percentage={NumberUtil.getPercentage(other, maxScheduleCount)} color="#c482ff"></ChartBar>
                             </div>
                         );
                     })}

--- a/src/components/weekly-statistics/WeeklyStatistics.tsx
+++ b/src/components/weekly-statistics/WeeklyStatistics.tsx
@@ -13,9 +13,15 @@ const cx = classNames.bind(style);
 const statisticsStore = StatisticsStore.instance;
 
 const WeeklyStatistics = observer(() => {
-    const { weeklyStatisticsDateInfoList, firstDateStringOfThisWeek, lastDateStringOfThisWeek, maxScheduleCount, toPrevWeek, toNextWeek } =
-        statisticsStore;
-    const isThisWeek = true; // 임시
+    const {
+        toPrevWeek,
+        toNextWeek,
+        isThisWeek,
+        firstDateStringOfThisWeek,
+        lastDateStringOfThisWeek,
+        maxScheduleCount,
+        weeklyStatisticsDateInfoList,
+    } = statisticsStore;
 
     return (
         <div className={cx('wrapper')}>

--- a/src/components/weekly-statistics/WeeklyStatistics.tsx
+++ b/src/components/weekly-statistics/WeeklyStatistics.tsx
@@ -26,7 +26,7 @@ const WeeklyStatistics = observer(() => {
 
     return (
         <div className={cx('wrapper')}>
-            <PeriodSelector toPrev={toPrevWeek} toNext={toNextWeek} disabled={isThisWeek}>
+            <PeriodSelector toPrev={toPrevWeek} toNext={toNextWeek} isNextDisabled={isThisWeek}>
                 {isThisWeek ? '이번 주' : `${firstDateStringOfThisWeek} - ${lastDateStringOfThisWeek}`}
             </PeriodSelector>
             <div className={cx('chart')}>

--- a/src/components/weekly-statistics/WeeklyStatistics.tsx
+++ b/src/components/weekly-statistics/WeeklyStatistics.tsx
@@ -3,10 +3,10 @@ import { observer } from 'mobx-react';
 import classNames from 'classnames/bind';
 import style from './WeeklyStatistics.scss';
 import StatisticsStore from '@stores/StatisticsStore';
-import ArrowIcon from '@icons/arrow/ArrowIcon';
-import { dayList, EArrowDirection } from '@defines/defines';
+import { dayList } from '@defines/defines';
 import { FormatUtil } from '@utils/FormatUtil';
 import { NumberUtil } from '@utils/NumberUtil';
+import PeriodSelector from '@components/common/period-selector/PeriodSelector';
 
 const cx = classNames.bind(style);
 
@@ -25,15 +25,9 @@ const WeeklyStatistics = observer(() => {
 
     return (
         <div className={cx('wrapper')}>
-            <div className={cx('arrow-container')}>
-                <button onClick={toPrevWeek}>
-                    <ArrowIcon direction={EArrowDirection.LEFT} />
-                </button>
-                <span>{isThisWeek ? '이번 주' : `${firstDateStringOfThisWeek} - ${lastDateStringOfThisWeek}`}</span>
-                <button onClick={toNextWeek} disabled={isThisWeek}>
-                    <ArrowIcon direction={EArrowDirection.RIGHT} />
-                </button>
-            </div>
+            <PeriodSelector toPrev={toPrevWeek} toNext={toNextWeek} disabled={isThisWeek}>
+                {isThisWeek ? '이번 주' : `${firstDateStringOfThisWeek} - ${lastDateStringOfThisWeek}`}
+            </PeriodSelector>
             <div className={cx('chart')}>
                 <div className={cx('chart__count')}>
                     <span>{maxScheduleCount}</span>

--- a/src/components/weekly-statistics/WeeklyStatistics.tsx
+++ b/src/components/weekly-statistics/WeeklyStatistics.tsx
@@ -7,6 +7,7 @@ import { dayList } from '@defines/defines';
 import { FormatUtil } from '@utils/FormatUtil';
 import { NumberUtil } from '@utils/NumberUtil';
 import PeriodSelector from '@components/common/period-selector/PeriodSelector';
+import ChartBar from '@components/common/chart-bar/ChartBar';
 
 const cx = classNames.bind(style);
 
@@ -38,12 +39,8 @@ const WeeklyStatistics = observer(() => {
                         const { me, other } = scheduleCountInfo;
                         return (
                             <div key={FormatUtil.calendarDateToString(calendarDate)} className={cx('bar')}>
-                                <div style={{ height: `${NumberUtil.getPercentage(me, maxScheduleCount)}%` }}>
-                                    <div style={{ backgroundColor: '#a34dff' }}></div>
-                                </div>
-                                <div style={{ height: `${NumberUtil.getPercentage(other, maxScheduleCount)}%` }}>
-                                    <div style={{ backgroundColor: '#c482ff' }}></div>
-                                </div>
+                                <ChartBar width={4} percentage={NumberUtil.getPercentage(me, maxScheduleCount)} color="#a34dff"></ChartBar>
+                                <ChartBar width={4} percentage={NumberUtil.getPercentage(other, maxScheduleCount)} color="#c482ff"></ChartBar>
                             </div>
                         );
                     })}

--- a/src/components/weekly-statistics/WeeklyStatistics.tsx
+++ b/src/components/weekly-statistics/WeeklyStatistics.tsx
@@ -13,16 +13,18 @@ const cx = classNames.bind(style);
 const statisticsStore = StatisticsStore.instance;
 
 const WeeklyStatistics = observer(() => {
-    const { weeklyStatisticsDateInfoList, maxScheduleCount } = statisticsStore;
+    const { weeklyStatisticsDateInfoList, firstDateStringOfThisWeek, lastDateStringOfThisWeek, maxScheduleCount, toPrevWeek, toNextWeek } =
+        statisticsStore;
+    const isThisWeek = true; // 임시
 
     return (
         <div className={cx('wrapper')}>
             <div className={cx('arrow-container')}>
-                <button>
+                <button onClick={toPrevWeek}>
                     <ArrowIcon direction={EArrowDirection.LEFT} />
                 </button>
-                <span>이번 주</span>
-                <button disabled={true}>
+                <span>{isThisWeek ? '이번 주' : `${firstDateStringOfThisWeek} - ${lastDateStringOfThisWeek}`}</span>
+                <button onClick={toNextWeek} disabled={isThisWeek}>
                     <ArrowIcon direction={EArrowDirection.RIGHT} />
                 </button>
             </div>
@@ -52,7 +54,7 @@ const WeeklyStatistics = observer(() => {
                     const { year, month, date } = calendarDate;
                     return (
                         <span key={FormatUtil.calendarDateToString(calendarDate)}>
-                            {FormatUtil.monthAndDateToString(month, date)}({dayList[new Date(year, month, date).getDay()]})
+                            {FormatUtil.calendarDateToStringExceptYear(calendarDate)}({dayList[new Date(year, month, date).getDay()]})
                         </span>
                     );
                 })}

--- a/src/stores/StatisticsStore.ts
+++ b/src/stores/StatisticsStore.ts
@@ -31,16 +31,13 @@ export default class StatisticsStore {
         return this._instance;
     }
 
-    get maxScheduleCount(): number {
-        return this._weeklyStatisticsInfo.maxScheduleCount;
-    }
-
-    get weeklyStatisticsDateInfoList(): WeeklyStatisticsDateInfo[] {
-        return this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList;
-    }
-    
     get dateOfThisWeek(): CalendarDate {
         return this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList[0].calendarDate;
+    }
+
+    get isThisWeek(): boolean {
+        const isThisWeek = ({ calendarDate }) => calendarDate.date === new Date().getDate();
+        return this.weeklyStatisticsDateInfoList.some(isThisWeek);
     }
 
     get firstDateStringOfThisWeek(): string {
@@ -49,6 +46,14 @@ export default class StatisticsStore {
 
     get lastDateStringOfThisWeek(): string {
         return FormatUtil.calendarDateToStringExceptYear(this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList[6].calendarDate);
+    }
+
+    get maxScheduleCount(): number {
+        return this._weeklyStatisticsInfo.maxScheduleCount;
+    }
+
+    get weeklyStatisticsDateInfoList(): WeeklyStatisticsDateInfo[] {
+        return this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList;
     }
 
     @action

--- a/src/stores/StatisticsStore.ts
+++ b/src/stores/StatisticsStore.ts
@@ -1,7 +1,9 @@
 import { autobind } from 'core-decorators';
 import { action, observable } from 'mobx';
-import { WeeklyStatisticsDateInfo, WeeklyStatisticsInfo } from '@defines/defines';
+import { CalendarDate, WeeklyStatisticsDateInfo, WeeklyStatisticsInfo } from '@defines/defines';
 import { StatisticsRequest } from '@requests/StatisticsRequest';
+import { DateUtil } from '@utils/DateUtil';
+import { FormatUtil } from '@utils/FormatUtil';
 
 @autobind
 export default class StatisticsStore {
@@ -36,9 +38,36 @@ export default class StatisticsStore {
     get weeklyStatisticsDateInfoList(): WeeklyStatisticsDateInfo[] {
         return this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList;
     }
+    
+    get dateOfThisWeek(): CalendarDate {
+        return this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList[0].calendarDate;
+    }
+
+    get firstDateStringOfThisWeek(): string {
+        return FormatUtil.calendarDateToStringExceptYear(this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList[0].calendarDate);
+    }
+
+    get lastDateStringOfThisWeek(): string {
+        return FormatUtil.calendarDateToStringExceptYear(this._weeklyStatisticsInfo.weeklyStatisticsDateInfoList[6].calendarDate);
+    }
 
     @action
     setWeeklyStatisticsInfo(weeklyStatisticsInfo: WeeklyStatisticsInfo) {
         this._weeklyStatisticsInfo = weeklyStatisticsInfo;
+    }
+
+    @action
+    toPrevWeek() {
+        this.changeWeek(DateUtil.getLastWeekDate(this.dateOfThisWeek));
+    }
+
+    @action
+    toNextWeek() {
+        this.changeWeek(DateUtil.getNextWeekDate(this.dateOfThisWeek));
+    }
+
+    @action
+    private async changeWeek(calendarDate: CalendarDate) {
+        this.setWeeklyStatisticsInfo(await StatisticsRequest.getWeeklyStatisticsInfo(calendarDate));
     }
 }

--- a/src/stores/StatisticsStore.ts
+++ b/src/stores/StatisticsStore.ts
@@ -13,13 +13,13 @@ export default class StatisticsStore {
 
     private constructor() {
         const today = new Date();
-        const todayObject = {
+        const todayDate = {
             year: today.getFullYear(),
             month: today.getMonth() + 1,
             date: today.getDate(),
         };
         (async () => {
-            this.setWeeklyStatisticsInfo(await StatisticsRequest.getWeeklyStatisticsInfo(todayObject));
+            this.setWeeklyStatisticsInfo(await StatisticsRequest.getWeeklyStatisticsInfo(todayDate));
         })();
         StatisticsStore._instance = this;
     }
@@ -36,7 +36,9 @@ export default class StatisticsStore {
     }
 
     get isThisWeek(): boolean {
-        const isThisWeek = ({ calendarDate }) => calendarDate.date === new Date().getDate();
+        const today = new Date();
+        const isThisWeek = ({ calendarDate }) =>
+            calendarDate.year === today.getFullYear() && calendarDate.month === today.getMonth() + 1 && calendarDate.date === today.getDate();
         return this.weeklyStatisticsDateInfoList.some(isThisWeek);
     }
 

--- a/src/stores/StatisticsStore.ts
+++ b/src/stores/StatisticsStore.ts
@@ -37,8 +37,10 @@ export default class StatisticsStore {
 
     get isThisWeek(): boolean {
         const today = new Date();
-        const isThisWeek = ({ calendarDate }) =>
-            calendarDate.year === today.getFullYear() && calendarDate.month === today.getMonth() + 1 && calendarDate.date === today.getDate();
+        const isThisWeek = ({ calendarDate }) => {
+            const { year, month, date } = calendarDate;
+            return year === today.getFullYear() && month === today.getMonth() + 1 && date === today.getDate();
+        };
         return this.weeklyStatisticsDateInfoList.some(isThisWeek);
     }
 

--- a/src/utils/FormatUtil.ts
+++ b/src/utils/FormatUtil.ts
@@ -16,11 +16,13 @@ export namespace FormatUtil {
     }
 
     /**
-     * month, date 값을 00.00 포맷의 문자열로 변환
-     * @param month
-     * @param date
+     * CalendarDate 객체를 00.00 포맷의 문자열로 변환
+     * @param calendarDate
      */
-    export function monthAndDateToString(month: number, date: number): string {
+    export function calendarDateToStringExceptYear(calendarDate: CalendarDate): string {
+        if (!calendarDate) return '';
+
+        const { month, date } = calendarDate;
         return `${withDigitLength(month, 2)}.${withDigitLength(date, 2)}`;
     }
 


### PR DESCRIPTION
close #56 

## 📋 작업 내용
- [x] 주 단위로 이동할 때마다 차트 바뀌도록 구현
- [x] 이번 주보다 이전으로 넘어가면 '이번 주'라는 텍스트 대신 '02.13 - 02.19' 형태의 텍스트가 뜨도록 구현
- [x] 미래의 차트는 확인할 수 없도록 버튼에 disabled 처리

## 📌 PR Point
- 저번 PR의 코드 리뷰를 참고하여 컴포넌트를 최대한 분리했습니다. ex. `PeriodSelector`, `ChartBar` 컴포넌트

- PeriodSelector 사용 예시
  ```typescript
  <PeriodSelector toPrev={toPrevWeek} toNext={toNextWeek} isNextDisabled={isThisWeek}>
      {isThisWeek ? '이번 주' : `${firstDateStringOfThisWeek} - ${lastDateStringOfThisWeek}`}
  </PeriodSelector>
  ```
  간단한 props 설명
  - toPrev : < 버튼 클릭 시 실행할 함수 (필수)
  - toNext : > 버튼 클릭 시 실행할 함수 (필수)
  - isPrevDisabled : < 버튼 비활성화 조건 만족 여부 (선택)
  - isNextDisabled : > 버튼 비활성화 조건 만족 여부 (선택)
  - children : <, > 버튼 사이에 들어갈 텍스트 (선택)
  
- FormatUtil.ts의 `monthAndDateToString` 함수를 지우고, `calendarDateToStringExceptYear` 함수를 만들었습니다. 
  → `month`, `date`값을 각각 가져오는 것보다 `calendarDate` 객체 하나만 가져와서 원하는 형태로 변환하는 것이 좋다고 생각

## 📷 스크린샷
![Screenshot](https://user-images.githubusercontent.com/58380158/154820604-4420adac-51f4-4635-93f9-ce4bf1e102b0.gif)


