### PR TITLE
[Feat] Dialog 컴포넌트에 애니메이션 추가

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -12,6 +12,7 @@
 
     body {
         line-height: 1;
+        overflow-y: hidden;
     }
 
     ol,

--- a/src/App.scss
+++ b/src/App.scss
@@ -28,6 +28,7 @@
         outline: none;
         cursor: pointer;
         background-color: Transparent;
+        color: #2d2d2d;
     }
 
     blockquote:before,
@@ -44,6 +45,7 @@
         height: 100%;
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         font-size: 5vw;
+        color: #2d2d2d;
     }
 
     .main {

--- a/src/components/common/dialog/Dialog.scss
+++ b/src/components/common/dialog/Dialog.scss
@@ -2,16 +2,30 @@
 
 .wrapper {
   @include screenMask($dialog-z-index);
+  transition: opacity .1s ease;
+
+  &.close {
+    opacity: 0;
+  }
 
   .dialog {
+    position: absolute;
     width: 74vw;
     height: 24vh;
+    top: calc(50% - 12vh);
     background-color: white;
     border-radius: 8px;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     line-height: 1.6;
+    transition: opacity .2s ease, top .2s ease;
+    animation: shake .2s ease-in-out;
+
+    &.close {
+      opacity: 0;
+      top: 50%;
+    }
 
     .message {
       height: 100%;
@@ -32,11 +46,11 @@
         font-size: 4vw;
 
         &.confirm {
-          color: #3998f6;
+          color: #7620ff;
         }
 
         &.cancel {
-          color: #f57171;
+          color: #505050;
         }
       }
     }

--- a/src/components/common/dialog/Dialog.tsx
+++ b/src/components/common/dialog/Dialog.tsx
@@ -1,10 +1,11 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import { observer } from 'mobx-react';
 import classNames from 'classnames/bind';
 import style from './Dialog.scss';
 import OverlayPortal from '@components/common/overlay-portal/OverlayPortal';
 import DialogStore from '@components/common/dialog/store/DialogStore';
 import { EDialogType } from '@defines/defines';
+import { ComponentUtil } from '@utils/ComponentUtil';
 
 const cx = classNames.bind(style);
 
@@ -37,9 +38,22 @@ export const dialog = {
 };
 
 const Dialog = observer(() => {
-    const { isOpened, message, onConfirm, onCancel, confirmText, cancelText, type, close } = store;
+    const { isOpened, message, onConfirm, onCancel, confirmText, cancelText, type, close, mounted, setMounted } = store;
 
-    if (!isOpened) return null;
+    const dialogRef = useRef<HTMLDivElement>();
+
+    useEffect(() => {
+        const element = dialogRef.current;
+        if (isOpened || !element) return;
+
+        ComponentUtil.unmountComponent<HTMLDivElement>(
+            element,
+            () => ComponentUtil.getCssStylePropertyValueFromElement(element, 'opacity') === '0',
+            () => setMounted(false),
+        );
+    }, [isOpened]);
+
+    if (!mounted) return null;
 
     const confirm = () => {
         close();
@@ -51,20 +65,22 @@ const Dialog = observer(() => {
         onCancel();
     };
 
+    const clsClose = !isOpened && 'close';
+
     return (
         <OverlayPortal>
-            <div className={cx('wrapper')}>
-                <div className={cx('dialog')}>
+            <div className={cx('wrapper', clsClose)}>
+                <div className={cx('dialog', clsClose)} ref={dialogRef}>
                     <div className={cx('message')}>{message}</div>
                     <div className={cx('buttons')}>
-                        <button onClick={confirm} className={cx('confirm')}>
-                            {confirmText}
-                        </button>
                         {type === EDialogType.CONFIRM && (
                             <button onClick={cancel} className={cx('cancel')}>
                                 {cancelText}
                             </button>
                         )}
+                        <button onClick={confirm} className={cx('confirm')}>
+                            {confirmText}
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/components/common/dialog/store/DialogStore.ts
+++ b/src/components/common/dialog/store/DialogStore.ts
@@ -14,6 +14,7 @@ export default class DialogStore {
     @observable private _type: EDialogType;
     @observable private _onConfirm: () => void = () => {};
     @observable private _onCancel: () => void = () => {};
+    @observable private _mounted: boolean;
 
     private constructor() {
         DialogStore._instance = this;
@@ -54,9 +55,14 @@ export default class DialogStore {
         return this._onCancel;
     }
 
+    get mounted(): boolean {
+        return this._mounted;
+    }
+
     @action
     open() {
         this._isOpened = true;
+        this.setMounted(true);
     }
 
     @action
@@ -96,5 +102,10 @@ export default class DialogStore {
     @action
     setOnCancel(value: () => void) {
         this._onCancel = value;
+    }
+
+    @action
+    setMounted(isMounted: boolean) {
+        this._mounted = isMounted;
     }
 }

--- a/src/components/common/toast/Toast.scss
+++ b/src/components/common/toast/Toast.scss
@@ -1,13 +1,5 @@
 @import "src/presets";
 
-@keyframes shake {
-  0% {opacity:0;transform:rotateX(0deg);}
-  30% {opacity:1;transform:rotateX(-50deg);}
-  60% {transform:rotateX(0deg);}
-  80% {transform:rotateX(-25deg);}
-  100% {transform:rotateX(0deg);}
-}
-
 @keyframes rise {
   0% {opacity:0;top:0;}
 }

--- a/src/components/common/toast/Toast.tsx
+++ b/src/components/common/toast/Toast.tsx
@@ -34,7 +34,7 @@ const Toast = observer(() => {
 
         ComponentUtil.unmountComponent<HTMLDivElement>(
             element,
-            () => window.getComputedStyle(element).getPropertyValue('opacity') === '0',
+            () => ComponentUtil.getCssStylePropertyValueFromElement(element, 'opacity') === '0',
             () => setMounted(false),
         );
     }, [isOpened]);

--- a/src/presets.scss
+++ b/src/presets.scss
@@ -43,5 +43,14 @@ $otherColor: #c482ff;
   text-overflow: ellipsis;
 }
 
+// 상하로 흔들리는 애니메이션
+@keyframes shake {
+  0% {opacity:0;transform:rotateX(0deg);}
+  30% {opacity:1;transform:rotateX(-50deg);}
+  60% {transform:rotateX(0deg);}
+  80% {transform:rotateX(-25deg);}
+  100% {transform:rotateX(0deg);}
+}
+
 // 아이폰11 414x896
 // Z-플립 540x1320

--- a/src/stores/ModalStore.ts
+++ b/src/stores/ModalStore.ts
@@ -14,13 +14,11 @@ export default class ModalStore {
         this._isOpened = true;
         this.init(initObj);
         openCallback && openCallback();
-        document.body.style.overflow = 'hidden';
     }
 
     @action
     close() {
         this._isOpened = false;
-        document.body.style.overflow = 'unset';
     }
 
     protected init(initObj?: any) {}

--- a/src/utils/ComponentUtil.ts
+++ b/src/utils/ComponentUtil.ts
@@ -23,4 +23,13 @@ export namespace ComponentUtil {
             }
         }, pollingInterval);
     }
+
+    /**
+     * element 에 적용되어 있는 css 스타일 중 특정 property 값을 조회
+     * @param element
+     * @param propertyName
+     */
+    export function getCssStylePropertyValueFromElement(element: HTMLElement, propertyName: string): string {
+        return window.getComputedStyle(element).getPropertyValue(propertyName);
+    }
 }


### PR DESCRIPTION
#62 
## 📋 작업 내용
- [x] confirm UI에 애니메이션 추가

## 📌 PR Point
- Toast UI 애니메이션과 유사하게 처리함
- 모달 열릴 때 `document.body.style.overflow = 'hidden';` 이 코드를 넣어 모달 뒤의 화면이 스크롤되지 않도록 했으나 모달이 내려가는 순간 아래로 스크롤 할 수 있는 문제로 인해 body 스타일 자체를 `overflow: hidden`으로 수정하였음.